### PR TITLE
fix: tag filter attribute

### DIFF
--- a/helper_dart/lib/src/filter.dart
+++ b/helper_dart/lib/src/filter.dart
@@ -84,7 +84,7 @@ class FilterTag implements Filter {
   const FilterTag._(this.value, [this.isNegated = false]);
 
   @override
-  final String attribute = '_tag';
+  final String attribute = '_tags';
   @override
   final bool isNegated;
   final String value;


### PR DESCRIPTION
Fix typo in the `FilterTag` attribute value: `_tag` -> `_tags`.