### PR TITLE
fix(queryBuilder): add objectID to attributes for aux queries

### DIFF
--- a/helper_dart/lib/src/query_builder.dart
+++ b/helper_dart/lib/src/query_builder.dart
@@ -101,8 +101,8 @@ class QueryBuilder {
         return query.copyWith(
           facets: [facet],
           filterGroups: filterGroupsCopy,
-          attributesToRetrieve: ['objectID'],// TODO: should be [], workaround
-          attributesToHighlight: ['objectID'],// to avoid the client exception
+          attributesToRetrieve: ['objectID'], // TODO: should be [], workaround
+          attributesToHighlight: ['objectID'], // to avoid the client exception
           hitsPerPage: 0,
           analytics: false,
         );

--- a/helper_dart/lib/src/query_builder.dart
+++ b/helper_dart/lib/src/query_builder.dart
@@ -101,8 +101,8 @@ class QueryBuilder {
         return query.copyWith(
           facets: [facet],
           filterGroups: filterGroupsCopy,
-          attributesToRetrieve: [],
-          attributesToHighlight: [],
+          attributesToRetrieve: ['objectID'],// TODO: should be [], workaround
+          attributesToHighlight: ['objectID'],// to avoid the client exception
           hitsPerPage: 0,
           analytics: false,
         );


### PR DESCRIPTION
Set `objectID` to `attributesToRetrieve` and `attributesToHighlight` in auxiliary queries generated by `QueryBuilder` to workaround the community client exception.