### PR TITLE
fix(HitsSearcher): re-run search with same state

### DIFF
--- a/helper_dart/lib/src/hits_searcher.dart
+++ b/helper_dart/lib/src/hits_searcher.dart
@@ -63,7 +63,6 @@ class HitsSearcher {
   HitsSearcher._(this.searchService, this._state, Duration debounce)
       : responses = _state.stream
             .debounceTime(debounce)
-            .distinct()
             .switchMap(searchService.search),
         _log = algoliaLogger('HitsSearcher');
 


### PR DESCRIPTION
Remove `distinct` from search state stream.