### PR TITLE
fix: deprecated `ImmutableFilters`

### DIFF
--- a/helper_dart/lib/src/filters.dart
+++ b/helper_dart/lib/src/filters.dart
@@ -56,6 +56,9 @@ abstract class Filters {
   });
 }
 
+@Deprecated("Renamed to 'StatelessFilters'")
+typedef ImmutableFilters = StatelessFilters;
+
 /// Stateless (immutable) filters implementation.
 /// **All operations create a new object with requested changes.**
 @sealed


### PR DESCRIPTION
Type aliasing `StatelessFilters` to `ImmutableFilters` to avoid API breaking changes and keep backward compatibility.