### PR TITLE
fix(searcher): same search query

### DIFF
--- a/helper_dart/lib/src/hits_searcher.dart
+++ b/helper_dart/lib/src/hits_searcher.dart
@@ -212,7 +212,6 @@ class _HitsSearcher with DisposableMixin implements HitsSearcher {
   /// Search responses subject
   late final _responses = _state.stream
       .debounceTime(debounce)
-      .distinct()
       .switchMap((state) => Stream.fromFuture(searchService.search(state)))
       .publish();
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | [FX-1955](https://algolia.atlassian.net/browse/FX-1955)
| Need Doc update   | no

---

Allow to use the same search state to run a search query. Useful to retry a search operation in case of a failure.
Distinct search operations can be implemented at text input level. Debounce will still discard repeated entries in the specified timeframe.