### PR TITLE
feat: add rerun search query

### DIFF
--- a/helper_dart/lib/src/hits_searcher.dart
+++ b/helper_dart/lib/src/hits_searcher.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:algolia_helper/src/search_request.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
@@ -10,6 +9,7 @@ import 'disposable_mixin.dart';
 import 'filter_state.dart';
 import 'hits_searcher_service.dart';
 import 'logger.dart';
+import 'search_request.dart';
 import 'search_response.dart';
 import 'search_state.dart';
 

--- a/helper_dart/lib/src/hits_searcher.dart
+++ b/helper_dart/lib/src/hits_searcher.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:algolia_helper/src/search_request.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
@@ -148,6 +149,9 @@ abstract class HitsSearcher implements Disposable {
 
   /// Apply search state configuration.
   void applyState(SearchState Function(SearchState state) config);
+
+  /// Re-run the last search query
+  void rerun();
 }
 
 /// Extensions over [HitsSearcher]
@@ -185,16 +189,21 @@ class _HitsSearcher with DisposableMixin implements HitsSearcher {
     HitsSearchService searchService,
     SearchState state, [
     Duration debounce = const Duration(milliseconds: 100),
-  ]) : this._(searchService, BehaviorSubject.seeded(state), debounce);
+  ]) : this._(
+          searchService,
+          BehaviorSubject.seeded(SearchRequest(state)),
+          debounce,
+        );
 
   /// HitsSearcher's private constructor
-  _HitsSearcher._(this.searchService, this._state, this.debounce) {
+  _HitsSearcher._(this.searchService, this._request, this.debounce) {
     _subscription = _responses.connect();
   }
 
   /// Search state stream
   @override
-  Stream<SearchState> get state => _state.stream;
+  Stream<SearchState> get state =>
+      _request.stream.map((request) => request.state);
 
   /// Search results stream
   @override
@@ -207,12 +216,13 @@ class _HitsSearcher with DisposableMixin implements HitsSearcher {
   final Duration debounce;
 
   /// Search state subject
-  final BehaviorSubject<SearchState> _state;
+  final BehaviorSubject<SearchRequest> _request;
 
   /// Search responses subject
-  late final _responses = _state.stream
+  late final _responses = _request.stream
       .debounceTime(debounce)
-      .switchMap((state) => Stream.fromFuture(searchService.search(state)))
+      .distinct()
+      .switchMap((req) => Stream.fromFuture(searchService.search(req.state)))
       .publish();
 
   /// Events logger
@@ -229,7 +239,7 @@ class _HitsSearcher with DisposableMixin implements HitsSearcher {
 
   /// Get current [SearchState].
   @override
-  SearchState snapshot() => _state.value;
+  SearchState snapshot() => _request.value.state;
 
   /// Apply search state configuration.
   @override
@@ -239,19 +249,28 @@ class _HitsSearcher with DisposableMixin implements HitsSearcher {
 
   /// Apply changes to the current state
   void _updateState(SearchState Function(SearchState state) apply) {
-    if (_state.isClosed) {
+    if (_request.isClosed) {
       _log.warning('modifying disposed instance');
       return;
     }
-    final current = _state.value;
-    final newState = apply(current);
-    _state.sink.add(newState);
+    final current = _request.value;
+    final newState = apply(current.state);
+    _request.sink.add(SearchRequest(newState));
+  }
+
+  @override
+  void rerun() {
+    final request = _request.value;
+    _request.value = request.copyWith(
+      state: request.state,
+      attempts: request.attempts + 1,
+    );
   }
 
   @override
   void doDispose() {
     _log.fine('HitsSearcher disposed');
-    _state.close();
+    _request.close();
     _subscription.cancel();
   }
 }

--- a/helper_dart/lib/src/hits_searcher.dart
+++ b/helper_dart/lib/src/hits_searcher.dart
@@ -260,11 +260,13 @@ class _HitsSearcher with DisposableMixin implements HitsSearcher {
 
   @override
   void rerun() {
-    final request = _request.value;
-    _request.value = request.copyWith(
-      state: request.state,
-      attempts: request.attempts + 1,
+    final current = _request.value;
+    final request = current.copyWith(
+      state: current.state,
+      attempts: current.attempts + 1,
     );
+    _log.fine('Rerun request: $request');
+    _request.sink.add(request);
   }
 
   @override

--- a/helper_dart/lib/src/search_request.dart
+++ b/helper_dart/lib/src/search_request.dart
@@ -1,0 +1,36 @@
+import 'search_state.dart';
+
+class SearchRequest {
+  /// Creates [SearchRequest] instance.
+  SearchRequest(this.state, [this.attempts = 1]);
+
+  /// Search state query
+  final SearchState state;
+
+  /// Count of query attempts
+  final int attempts;
+
+  /// Create a copy with given parameters.
+  SearchRequest copyWith({
+    SearchState? state,
+    int? attempts,
+  }) =>
+      SearchRequest(
+        state ?? this.state,
+        attempts ?? this.attempts,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SearchRequest &&
+          runtimeType == other.runtimeType &&
+          state == other.state &&
+          attempts == other.attempts;
+
+  @override
+  int get hashCode => state.hashCode ^ attempts.hashCode;
+
+  @override
+  String toString() => 'SearchRequest{state: $state, attempt: $attempts}';
+}

--- a/helper_dart/test/hits_searcher_test.dart
+++ b/helper_dart/test/hits_searcher_test.dart
@@ -156,6 +156,35 @@ void main() {
       searcher.query('cat');
       await delay(50);
     });
+
+    test('Should rerun requests', () async {
+      final searchService = MockHitsSearchService();
+      when(searchService.search(any)).thenAnswer(mockResponse);
+
+      final searcher = HitsSearcher.custom(
+        searchService,
+        const SearchState(indexName: 'myIndex'),
+      );
+
+      searcher.responses.listen(print);
+
+      unawaited(
+        expectLater(
+          searcher.responses,
+          emitsInOrder([
+            emits(matchesQuery('cat')),
+            emits(matchesQuery('cat')),
+          ]),
+        ),
+      );
+
+      searcher.query('cat');
+      await delay();
+      searcher.query('cat'); // should be ignored
+      await delay();
+      searcher.rerun();
+      await delay();
+    });
   });
 
   test('FilterState connect HitsSearcher', () async {


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        | no   |
| New feature?    | yes   |
| BC breaks?      | no       |
| Related Issue   | FX-2128 |
| Need Doc update | no   |

## Describe your change

- Add `rerun` search query capability
- Reverts back distinct search operations behavior