### PR TITLE
fix(HitsSearcher): use `x-algolia-agent` for extra headers

### DIFF
--- a/helper_dart/lib/src/hits_searcher.dart
+++ b/helper_dart/lib/src/hits_searcher.dart
@@ -8,7 +8,6 @@ import 'disposable.dart';
 import 'disposable_mixin.dart';
 import 'filter_state.dart';
 import 'hits_searcher_service.dart';
-import 'lib_version.dart';
 import 'logger.dart';
 import 'search_request.dart';
 import 'search_response.dart';
@@ -179,7 +178,6 @@ class _HitsSearcher with DisposableMixin implements HitsSearcher {
     final service = AlgoliaSearchService(
       applicationID: applicationID,
       apiKey: apiKey,
-      extraUserAgents: ['algolia-helper-dart ($libVersion)'],
       disjunctiveFacetingEnabled: disjunctiveFacetingEnabled,
     );
     return _HitsSearcher.create(service, state, debounce);

--- a/helper_dart/lib/src/hits_searcher_service.dart
+++ b/helper_dart/lib/src/hits_searcher_service.dart
@@ -5,6 +5,7 @@ import 'exception.dart';
 import 'extensions.dart';
 import 'filter_group.dart';
 import 'filter_group_converter.dart';
+import 'lib_version.dart';
 import 'logger.dart';
 import 'query_builder.dart';
 import 'search_response.dart';
@@ -22,13 +23,14 @@ class AlgoliaSearchService implements HitsSearchService {
   AlgoliaSearchService({
     required String applicationID,
     required String apiKey,
-    required List<String> extraUserAgents,
     required bool disjunctiveFacetingEnabled,
   }) : this.create(
           Algolia.init(
             applicationId: applicationID,
             apiKey: apiKey,
-            extraUserAgents: extraUserAgents,
+            extraHeaders: {
+              'x-algolia-agent': 'algolia-helper-dart ($libVersion)'
+            },
           ),
           disjunctiveFacetingEnabled,
         );


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        | yes   |
| New feature?    | no   |
| BC breaks?      | no       |
| Related Issue   | Fix #55 |
| Need Doc update | no   |

## Describe your change

Use `x-algolia-agent` instead of `user-agent` header.

_TODO: Dart API client shouldn't override `user-agent`, this not allowed by some web browsers._ 
