### PR TITLE
feat: search parameters for around queries

### DIFF
--- a/helper_dart/CHANGELOG.md
+++ b/helper_dart/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## [0.3.2](https://github.com/algolia/algoliasearch-helper-flutter/compare/0.3.1...0.3.2) (2022-04-07)
+
+### Feat
+
+- Add 'aroundLagLngViaIP', 'aroundLatLng', 'aroundRadius', 'aroundPrecision', 'minimumAroundRadius', and 'insideBoundingBox' to `SearchParameters`
+
 ## [0.3.1](https://github.com/algolia/algoliasearch-helper-flutter/compare/0.3.0...0.3.1) (2022-05-19)
 
 ### Fix

--- a/helper_dart/lib/src/hits_searcher.dart
+++ b/helper_dart/lib/src/hits_searcher.dart
@@ -107,7 +107,7 @@ abstract class HitsSearcher implements Disposable, EventDataDelegate {
       _HitsSearcher(
         applicationID: applicationID,
         apiKey: apiKey,
-        state: SearchState(indexName: indexName, clickAnalytics: true),
+        state: SearchState(indexName: indexName),
         disjunctiveFacetingEnabled: disjunctiveFacetingEnabled,
         debounce: debounce,
       );
@@ -123,7 +123,7 @@ abstract class HitsSearcher implements Disposable, EventDataDelegate {
       _HitsSearcher(
         applicationID: applicationID,
         apiKey: apiKey,
-        state: state.copyWith(clickAnalytics: true),
+        state: state,
         disjunctiveFacetingEnabled: disjunctiveFacetingEnabled,
         debounce: debounce,
       );

--- a/helper_dart/lib/src/hits_searcher_service.dart
+++ b/helper_dart/lib/src/hits_searcher_service.dart
@@ -133,8 +133,20 @@ extension AlgoliaExt on Algolia {
     state.aroundPrecision?.let((it) => query = query.setAroundPrecision(it));
     state.minimumAroundRadius
         ?.let((it) => query = query.setMinimumAroundRadius(it));
-    state.insideBoundingBox
-        ?.let((it) => query = query.setInsideBoundingBox(it));
+    state.insideBoundingBox?.let(
+      (it) => query = query.setInsideBoundingBox(
+        it
+            .map(
+              (e) => BoundingBox(
+                p1Lat: e[0],
+                p1Lng: e[1],
+                p2Lat: e[2],
+                p2Lng: e[3],
+              ),
+            )
+            .toList(),
+      ),
+    );
     return query;
   }
 

--- a/helper_dart/lib/src/hits_searcher_service.dart
+++ b/helper_dart/lib/src/hits_searcher_service.dart
@@ -25,13 +25,13 @@ class AlgoliaSearchService implements HitsSearchService {
     required List<String> extraUserAgents,
     required bool disjunctiveFacetingEnabled,
   }) : this.create(
-    Algolia.init(
-      applicationId: applicationID,
-      apiKey: apiKey,
-      extraUserAgents: extraUserAgents,
-    ),
-    disjunctiveFacetingEnabled,
-  );
+          Algolia.init(
+            applicationId: applicationID,
+            apiKey: apiKey,
+            extraUserAgents: extraUserAgents,
+          ),
+          disjunctiveFacetingEnabled,
+        );
 
   /// Creates [HitsSearchService] instance.
   AlgoliaSearchService.create(this._client, this._disjunctiveFacetingEnabled)
@@ -73,7 +73,7 @@ class AlgoliaSearchService implements HitsSearchService {
       final queryBuilder = QueryBuilder(state);
       final queries = queryBuilder.build().map(_client.queryOf).toList();
       final responses =
-      await _client.multipleQueries.addQueries(queries).getObjects();
+          await _client.multipleQueries.addQueries(queries).getObjects();
       _log.fine('Search responses: $responses');
       return queryBuilder
           .merge(responses.map((r) => r.toSearchResponse()).toList());
@@ -123,16 +123,18 @@ extension AlgoliaExt on Algolia {
     state.aroundLatLng?.let((it) => query = query.setAroundLatLng(it));
 
     // ?.let does not work on dynamic types
-    if(state.aroundRadius is String) {
+    if (state.aroundRadius is String) {
       query = query.setAroundRadius('all');
     }
-    if(state.aroundRadius is int) {
+    if (state.aroundRadius is int) {
       query = query.setAroundRadius(state.aroundRadius);
     }
 
     state.aroundPrecision?.let((it) => query = query.setAroundPrecision(it));
     state.minimumAroundRadius
         ?.let((it) => query = query.setMinimumAroundRadius(it));
+    state.insideBoundingBox
+        ?.let((it) => query = query.setInsideBoundingBox(it));
     return query;
   }
 

--- a/helper_dart/lib/src/hits_searcher_service.dart
+++ b/helper_dart/lib/src/hits_searcher_service.dart
@@ -25,13 +25,13 @@ class AlgoliaSearchService implements HitsSearchService {
     required List<String> extraUserAgents,
     required bool disjunctiveFacetingEnabled,
   }) : this.create(
-          Algolia.init(
-            applicationId: applicationID,
-            apiKey: apiKey,
-            extraUserAgents: extraUserAgents,
-          ),
-          disjunctiveFacetingEnabled,
-        );
+    Algolia.init(
+      applicationId: applicationID,
+      apiKey: apiKey,
+      extraUserAgents: extraUserAgents,
+    ),
+    disjunctiveFacetingEnabled,
+  );
 
   /// Creates [HitsSearchService] instance.
   AlgoliaSearchService.create(this._client, this._disjunctiveFacetingEnabled)
@@ -61,7 +61,7 @@ class AlgoliaSearchService implements HitsSearchService {
       _log.fine('Search response: $response');
       return response.toSearchResponse();
     } catch (exception) {
-      _log.severe('Search exception: $exception');
+      _log.severe('Search exception: $exception', exception);
       throw _launderException(exception);
     }
   }
@@ -73,12 +73,12 @@ class AlgoliaSearchService implements HitsSearchService {
       final queryBuilder = QueryBuilder(state);
       final queries = queryBuilder.build().map(_client.queryOf).toList();
       final responses =
-          await _client.multipleQueries.addQueries(queries).getObjects();
+      await _client.multipleQueries.addQueries(queries).getObjects();
       _log.fine('Search responses: $responses');
       return queryBuilder
           .merge(responses.map((r) => r.toSearchResponse()).toList());
     } catch (exception) {
-      _log.severe('Search exception thrown: $exception');
+      _log.severe('Search exception thrown: $exception', exception);
       throw _launderException(exception);
     }
   }
@@ -118,8 +118,21 @@ extension AlgoliaExt on Algolia {
     state.tagFilters?.let((it) => query = query.setTagFilters(it));
     state.userToken?.let((it) => query = query.setUserToken(it));
     state.filterGroups?.let((it) => query = query.setFilterGroups(it));
-    state.clickAnalytics
-        ?.let((it) => query = query.setClickAnalytics(enabled: it));
+    state.aroundLatLngViaIP
+        ?.let((it) => query = query.setAroundLatLngViaIP(it));
+    state.aroundLatLng?.let((it) => query = query.setAroundLatLng(it));
+
+    // ?.let does not work on dynamic types
+    if(state.aroundRadius is String) {
+      query = query.setAroundRadius('all');
+    }
+    if(state.aroundRadius is int) {
+      query = query.setAroundRadius(state.aroundRadius);
+    }
+
+    state.aroundPrecision?.let((it) => query = query.setAroundPrecision(it));
+    state.minimumAroundRadius
+        ?.let((it) => query = query.setMinimumAroundRadius(it));
     return query;
   }
 

--- a/helper_dart/lib/src/search_state.dart
+++ b/helper_dart/lib/src/search_state.dart
@@ -1,5 +1,3 @@
-import 'package:algolia/algolia.dart';
-
 import 'extensions.dart';
 import 'filter_group.dart';
 
@@ -285,7 +283,7 @@ class SearchState {
   ///
   /// Source: [Learn more](https://www.algolia.com/doc/api-reference/api-parameters/insideBoundingBox/)
   ///
-  final List<BoundingBox>? insideBoundingBox;
+  final List<List<double>>? insideBoundingBox;
 
   /// Make a copy of the search state.
   SearchState copyWith({
@@ -316,7 +314,7 @@ class SearchState {
     dynamic aroundRadius,
     int? aroundPrecision,
     int? minimumAroundRadius,
-    List<BoundingBox>? insideBoundingBox,
+    List<List<double>>? insideBoundingBox,
   }) =>
       SearchState(
         attributesToHighlight:

--- a/helper_dart/lib/src/search_state.dart
+++ b/helper_dart/lib/src/search_state.dart
@@ -39,7 +39,11 @@ class SearchState {
     this.sumOrFiltersScore,
     this.tagFilters,
     this.userToken,
-    this.clickAnalytics,
+    this.aroundLatLngViaIP,
+    this.aroundLatLng,
+    this.aroundRadius,
+    this.minimumAroundRadius,
+    this.aroundPrecision,
   });
 
   /// Index name
@@ -115,9 +119,11 @@ class SearchState {
   /// Whether the current query will be taken into account in the Analytics.
   final bool? analytics;
 
-  /// Add a query ID parameter to the response for tracking click and conversion
-  /// events.
-  final bool? clickAnalytics;
+  final bool? aroundLatLngViaIP;
+  final String? aroundLatLng;
+  final dynamic? aroundRadius;
+  final int? aroundPrecision;
+  final int? minimumAroundRadius;
 
   /// Make a copy of the search state.
   SearchState copyWith({
@@ -143,11 +149,15 @@ class SearchState {
     int? maxFacetHits,
     int? maxValuesPerFacet,
     int? page,
-    bool? clickAnalytics,
+    bool? aroundLatLngViaIP,
+    String? aroundLatLng,
+    dynamic? aroundRadius,
+    int? aroundPrecision,
+    int? minimumAroundRadius,
   }) =>
       SearchState(
         attributesToHighlight:
-            attributesToHighlight ?? this.attributesToHighlight,
+        attributesToHighlight ?? this.attributesToHighlight,
         attributesToRetrieve: attributesToRetrieve ?? this.attributesToRetrieve,
         attributesToSnippet: attributesToSnippet ?? this.attributesToSnippet,
         facetFilters: facetFilters ?? this.facetFilters,
@@ -169,37 +179,45 @@ class SearchState {
         maxFacetHits: maxFacetHits ?? this.maxFacetHits,
         maxValuesPerFacet: maxValuesPerFacet ?? this.maxValuesPerFacet,
         page: page ?? this.page,
-        clickAnalytics: clickAnalytics ?? this.clickAnalytics,
+        aroundLatLngViaIP: aroundLatLngViaIP ?? this.aroundLatLngViaIP,
+        aroundLatLng: aroundLatLng ?? this.aroundLatLng,
+        aroundRadius: aroundRadius ?? this.aroundRadius,
+        aroundPrecision: aroundPrecision ?? this.aroundPrecision,
+        minimumAroundRadius: minimumAroundRadius ?? this.minimumAroundRadius,
       );
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is SearchState &&
-          runtimeType == other.runtimeType &&
-          indexName == other.indexName &&
-          query == other.query &&
-          page == other.page &&
-          hitsPerPage == other.hitsPerPage &&
-          facets.equals(other.facets) &&
-          disjunctiveFacets.equals(other.disjunctiveFacets) &&
-          filterGroups.equals(other.filterGroups) &&
-          ruleContexts.equals(other.ruleContexts) &&
-          facetFilters.equals(other.facetFilters) &&
-          attributesToHighlight.equals(other.attributesToHighlight) &&
-          attributesToRetrieve.equals(other.attributesToRetrieve) &&
-          attributesToSnippet.equals(other.attributesToSnippet) &&
-          highlightPostTag == other.highlightPostTag &&
-          highlightPreTag == other.highlightPreTag &&
-          maxFacetHits == other.maxFacetHits &&
-          maxValuesPerFacet == other.maxValuesPerFacet &&
-          numericFilters.equals(other.numericFilters) &&
-          optionalFilters.equals(other.optionalFilters) &&
-          sumOrFiltersScore == other.sumOrFiltersScore &&
-          tagFilters.equals(other.tagFilters) &&
-          analytics == other.analytics &&
-          userToken == other.userToken &&
-          clickAnalytics == other.clickAnalytics;
+          other is SearchState &&
+              runtimeType == other.runtimeType &&
+              indexName == other.indexName &&
+              query == other.query &&
+              page == other.page &&
+              hitsPerPage == other.hitsPerPage &&
+              facets.equals(other.facets) &&
+              disjunctiveFacets.equals(other.disjunctiveFacets) &&
+              filterGroups.equals(other.filterGroups) &&
+              ruleContexts.equals(other.ruleContexts) &&
+              facetFilters.equals(other.facetFilters) &&
+              attributesToHighlight.equals(other.attributesToHighlight) &&
+              attributesToRetrieve.equals(other.attributesToRetrieve) &&
+              attributesToSnippet.equals(other.attributesToSnippet) &&
+              highlightPostTag == other.highlightPostTag &&
+              highlightPreTag == other.highlightPreTag &&
+              maxFacetHits == other.maxFacetHits &&
+              maxValuesPerFacet == other.maxValuesPerFacet &&
+              numericFilters.equals(other.numericFilters) &&
+              optionalFilters.equals(other.optionalFilters) &&
+              sumOrFiltersScore == other.sumOrFiltersScore &&
+              tagFilters.equals(other.tagFilters) &&
+              analytics == other.analytics &&
+              userToken == other.userToken &&
+              aroundLatLngViaIP == other.aroundLatLngViaIP &&
+              aroundLatLng == other.aroundLatLng &&
+              aroundRadius == other.aroundRadius &&
+              aroundPrecision == other.aroundPrecision &&
+              minimumAroundRadius == other.minimumAroundRadius;
 
   @override
   int get hashCode =>
@@ -225,7 +243,11 @@ class SearchState {
       tagFilters.hashing() ^
       analytics.hashCode ^
       userToken.hashCode ^
-      clickAnalytics.hashCode;
+      aroundLatLngViaIP.hashCode ^
+      aroundLatLng.hashCode ^
+      aroundRadius.hashCode ^
+      aroundPrecision.hashCode ^
+      minimumAroundRadius.hashCode;
 
   @override
   String toString() => 'SearchState{'
@@ -251,5 +273,11 @@ class SearchState {
       'sumOrFiltersScore: $sumOrFiltersScore, '
       'tagFilters: $tagFilters, '
       'userToken: $userToken, '
-      'clickAnalytics: $clickAnalytics}';
+      'aroundLatLngViaIP: $aroundLatLngViaIP, '
+      'aroundLatLng: $aroundLatLng, '
+      'aroundRadius: $aroundRadius, '
+      'aroundPrecision: $aroundPrecision, '
+      'minimumAroundRadius: $minimumAroundRadius, '
+      '}'
+  ;
 }

--- a/helper_dart/lib/src/search_state.dart
+++ b/helper_dart/lib/src/search_state.dart
@@ -1,3 +1,5 @@
+import 'package:algolia/algolia.dart';
+
 import 'extensions.dart';
 import 'filter_group.dart';
 
@@ -44,6 +46,7 @@ class SearchState {
     this.aroundRadius,
     this.minimumAroundRadius,
     this.aroundPrecision,
+    this.insideBoundingBox,
   });
 
   /// Index name
@@ -119,11 +122,170 @@ class SearchState {
   /// Whether the current query will be taken into account in the Analytics.
   final bool? analytics;
 
+  ///
+  /// **AroundLatLngViaIP**
+  ///
+  /// Search for entries around a given location automatically computed from the requester’s IP address.
+  /// By computing a central geolocation (from an IP), this has three consequences:
+  ///   - a radius / circle is computed automatically, based on the density of the records near the point defined by this setting
+  ///   - only records that fall within the bounds of the circle are returned
+  ///   - records are ranked according to the distance from the center of the circle
+  ///
+  /// **Usage notes:**
+  ///   - With this setting, you are using the end user’s IP to define a central axis point of a circle in geo-coordinates.
+  ///   - Algolia automatically calculates the size of the circular radius around this central axis.
+  ///     - To control the precise size of the radius, you would use [aroundRadius].
+  ///     - To control a minimum size, you would use [minimumAroundRadius].
+  ///   - If you are sending the request from your servers, you must set the X-Forwarded-For HTTP header with the front-end user’s IP address for it to be used as the basis for the computation of the search location.
+  ///   - Note: This setting differs from [aroundLatLng], which allows you to specify the exact latitude and longitude of the center of the circle.
+  ///   - This parameter will be ignored if used along with [insideBoundingBox] or [insidePolygon]
+  ///   - We currently only support IPv4 addresses. If the end user has an IPv6 address, this parameter won’t work as intended.
+  ///
+  /// Source: [Learn more](https://www.algolia.com/doc/api-reference/api-parameters/aroundLatLngViaIP/)
+  ///
   final bool? aroundLatLngViaIP;
+
+  ///
+  /// **AroundLatLng**
+  ///
+  /// Search for entries around a central geolocation, enabling a geo search within a circular area.
+  ///
+  /// By defining this central point, there are three consequences:
+  ///   - a radius / circle is computed automatically, based on the density of the records near the point defined by this setting
+  ///   - only records that fall within the bounds of the circle are returned
+  ///   - records are ranked according to the distance from the center of the circle
+  ///
+  /// **Usage notes:**
+  ///   - With this setting, you are defining a central point of a circle, whose geo-coordinates are expressed as two floats separated by a comma.
+  ///   - Note: This setting differs from [aroundLatLngViaIP], which uses the end user’s IP to determine the geo-coordinates.
+  ///   - This parameter will be ignored if used along with [insideBoundingBox] or [insidePolygon]
+  ///   - To control the maximum size of the radius, you would use [aroundRadius].
+  ///   - To control the minimum size, you would use [minimumAroundRadius].
+  ///   - The size of this radius depends on the density of the area around the central point. If there are a large number of hits close to the central point, the radius can be small. The less hits near the center, the larger the radius will be.
+  ///   - Note: If the results returned are less than the number of hits per page (hitsPerPage), then the number returned will be less than the hitsPerPage. For example, if you recieve 15 results, you could still see a larger number of hits per page, such as hitsPerPage=20.
+  ///
+  /// Source: [Learn more](https://www.algolia.com/doc/api-reference/api-parameters/aroundLatLng/)
+  ///
   final String? aroundLatLng;
+
+  ///
+  /// **AroundRadius**
+  ///
+  /// Define the maximum radius for a geo search (in meters).
+  ///
+  /// **Usage notes:**
+  ///   - This setting only works within the context of a radial (circuler) geo search,
+  ///     enabled by `aroundLatLngViaIP` or `aroundLatLng`.
+  ///   - ***How the radius is calculated:***
+  ///     - If you specify the meters of the radius (instead of `all`), then only records
+  ///       that fall within the bounds of the circle (as defined by the radius) will be
+  ///       returned. Additionally, the ranking of the returned hits will be based on the
+  ///       distance from the central axist point.
+  ///     - If you use `all`, there is no longer any filtering based on the radius. All
+  ///       relevant results are returned, but the ranking is still based on the distance
+  ///       from the central axis point.
+  ///     - If you do not use this setting, and yet perform a radial geo search (using
+  ///       `aroundLatLngViaIP` or `aroundLatLng`), the radius is automatically computed
+  ///       from the density of the searched area. See also `minimumAroundRadius`, which
+  ///       determines the minimum size of the radius.
+  ///   - For this setting to have any effect on your ranking, the geo criterion must be
+  ///     included in your ranking formula (which is the case by default).
+  ///
+  /// **Options:**
+  ///   - `radius_in_meters`: Integer value (in meters) representing the radius around the
+  ///     coordinates specified during the query.
+  ///   - `all`: Disables the radius logic, allowing all results to be returned, regardless
+  ///     of distance. Ranking is still based on proxiùmity to the central axis point. This
+  ///     option is faster than specifying a high integer value.
+  ///
+  /// value must be a `int` or `'all'`
+  ///
+  /// `1 = 1 Meter`
+  ///
+  /// `Therefore for 1000 = 1 Kilometer`
+  ///
+  /// `'aroundRadius' => 1000` // 1km
+  ///
+  /// Source: [Learn more](https://www.algolia.com/doc/api-reference/api-parameters/aroundRadius/)
+  ///
   final dynamic aroundRadius;
+
+  ///
+  /// **AroundPrecision**
+  ///
+  /// Precision of geo search (in meters), to add grouping by geo location to the ranking
+  /// formula.
+  ///
+  /// When ranking hits, geo distances are grouped into ranges of `aroundPrecision` size.
+  /// All hits within the same range are considered equal with respect to the `geo` ranking
+  /// parameter.
+  ///
+  /// For example, if you set `aroundPrecision` to `100`, any two objects lying in the range
+  /// `[0, 99m]` from the searched location will be considered equal; same for `[100, 199]`,
+  /// `[200, 299]`, etc.
+  ///
+  /// Usage notes:
+  ///   - For this setting to have any effect, the [geo criterion](https://www.algolia.com/doc/guides/managing-results/must-do/custom-ranking/in-depth/ranking-criteria#geo-if-applicable)
+  ///     must be included in your ranking formula (which is the case by default).
+  ///
+  /// `1 = 1 Meter`
+  ///
+  /// `Therefore for 1000 = 1 Kilometer`
+  ///
+  /// `'aroundPrecision' => 1000` // 1km
+  ///
+  /// Source: [Learn more](https://www.algolia.com/doc/api-reference/api-parameters/aroundPrecision/)
+  ///
   final int? aroundPrecision;
+
+  ///
+  /// **MinimumAroundRadius**
+  ///
+  /// Minimum radius (in meters) used for a geo search when `aroundRadius` is not set.
+  ///
+  /// When a radius is automatically generated, the area of the circle might be too
+  /// small to include enough records. This setting allows you to increase the size
+  /// of the circle, thus ensuring sufficient coverage.
+  ///
+  /// **Usage notes:**
+  ///   - This setting only works within the context of a circular geo search,
+  ///     enabled by `aroundLatLng` or `aroundLatLngViaIP`.
+  ///   - This parameter is ignored when `aroundRadius` is set.
+  ///
+  /// `1 = 1 Meter`
+  ///
+  /// `Therefore for 1000 = 1 Kilometer`
+  ///
+  /// `'minimumAroundRadius' => 1000` // 1km
+  ///
+  /// Source: [Learn more](https://www.algolia.com/doc/api-reference/api-parameters/minimumAroundRadius/)
+  ///
   final int? minimumAroundRadius;
+
+  ///
+  /// **InsideBoundingBox**
+  ///
+  /// Search inside a rectangular area (in geo coordinates).
+  ///
+  /// The rectangle is defined by two diagonally opposite points (hereafter `p1` and `p2`),
+  /// hence by 4 floats: `p1Lat`, `p1Lng`, `p2Lat`, `p2Lng`.
+  ///
+  /// For example: `insideBoundingBox = [ 47.3165, 4.9665, 47.3424, 5.0201 ]`
+  ///
+  /// **Usage notes**
+  ///   - You may specify multiple bounding boxes, in which case the search will use the
+  ///     union (OR) of the rectangles. To do this, pass either:
+  ///     - more than 4 values (must be a multiple of 4: 8, 12…); example:
+  ///       `47.3165,4.9665,47.3424,5.0201,40.9234,2.1185,38.6430,1.9916`; or
+  ///     - an list of lists of floats (each inner array must contain exactly 4 values);
+  ///       example: `[[47.3165, 4.9665, 47.3424, 5.0201], [40.9234, 2.1185, 38.6430, 1.9916]]`.
+  ///   - [aroundLatLng] and [aroundLatLngViaIP] will be ignored if used along with this
+  ///     parameter.
+  ///   - Be careful when your coordinates cross over the `180th meridian`.
+  ///
+  /// Source: [Learn more](https://www.algolia.com/doc/api-reference/api-parameters/insideBoundingBox/)
+  ///
+  final List<BoundingBox>? insideBoundingBox;
 
   /// Make a copy of the search state.
   SearchState copyWith({
@@ -154,6 +316,7 @@ class SearchState {
     dynamic aroundRadius,
     int? aroundPrecision,
     int? minimumAroundRadius,
+    List<BoundingBox>? insideBoundingBox,
   }) =>
       SearchState(
         attributesToHighlight:
@@ -184,6 +347,7 @@ class SearchState {
         aroundRadius: aroundRadius ?? this.aroundRadius,
         aroundPrecision: aroundPrecision ?? this.aroundPrecision,
         minimumAroundRadius: minimumAroundRadius ?? this.minimumAroundRadius,
+        insideBoundingBox: insideBoundingBox ?? this.insideBoundingBox,
       );
 
   @override
@@ -217,7 +381,8 @@ class SearchState {
           aroundLatLng == other.aroundLatLng &&
           aroundRadius == other.aroundRadius &&
           aroundPrecision == other.aroundPrecision &&
-          minimumAroundRadius == other.minimumAroundRadius;
+          minimumAroundRadius == other.minimumAroundRadius &&
+          insideBoundingBox.equals(other.insideBoundingBox);
 
   @override
   int get hashCode =>
@@ -247,7 +412,8 @@ class SearchState {
       aroundLatLng.hashCode ^
       aroundRadius.hashCode ^
       aroundPrecision.hashCode ^
-      minimumAroundRadius.hashCode;
+      minimumAroundRadius.hashCode ^
+      insideBoundingBox.hashing();
 
   @override
   String toString() => 'SearchState{'

--- a/helper_dart/lib/src/search_state.dart
+++ b/helper_dart/lib/src/search_state.dart
@@ -121,7 +121,7 @@ class SearchState {
 
   final bool? aroundLatLngViaIP;
   final String? aroundLatLng;
-  final dynamic? aroundRadius;
+  final dynamic aroundRadius;
   final int? aroundPrecision;
   final int? minimumAroundRadius;
 
@@ -151,13 +151,13 @@ class SearchState {
     int? page,
     bool? aroundLatLngViaIP,
     String? aroundLatLng,
-    dynamic? aroundRadius,
+    dynamic aroundRadius,
     int? aroundPrecision,
     int? minimumAroundRadius,
   }) =>
       SearchState(
         attributesToHighlight:
-        attributesToHighlight ?? this.attributesToHighlight,
+            attributesToHighlight ?? this.attributesToHighlight,
         attributesToRetrieve: attributesToRetrieve ?? this.attributesToRetrieve,
         attributesToSnippet: attributesToSnippet ?? this.attributesToSnippet,
         facetFilters: facetFilters ?? this.facetFilters,
@@ -189,35 +189,35 @@ class SearchState {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is SearchState &&
-              runtimeType == other.runtimeType &&
-              indexName == other.indexName &&
-              query == other.query &&
-              page == other.page &&
-              hitsPerPage == other.hitsPerPage &&
-              facets.equals(other.facets) &&
-              disjunctiveFacets.equals(other.disjunctiveFacets) &&
-              filterGroups.equals(other.filterGroups) &&
-              ruleContexts.equals(other.ruleContexts) &&
-              facetFilters.equals(other.facetFilters) &&
-              attributesToHighlight.equals(other.attributesToHighlight) &&
-              attributesToRetrieve.equals(other.attributesToRetrieve) &&
-              attributesToSnippet.equals(other.attributesToSnippet) &&
-              highlightPostTag == other.highlightPostTag &&
-              highlightPreTag == other.highlightPreTag &&
-              maxFacetHits == other.maxFacetHits &&
-              maxValuesPerFacet == other.maxValuesPerFacet &&
-              numericFilters.equals(other.numericFilters) &&
-              optionalFilters.equals(other.optionalFilters) &&
-              sumOrFiltersScore == other.sumOrFiltersScore &&
-              tagFilters.equals(other.tagFilters) &&
-              analytics == other.analytics &&
-              userToken == other.userToken &&
-              aroundLatLngViaIP == other.aroundLatLngViaIP &&
-              aroundLatLng == other.aroundLatLng &&
-              aroundRadius == other.aroundRadius &&
-              aroundPrecision == other.aroundPrecision &&
-              minimumAroundRadius == other.minimumAroundRadius;
+      other is SearchState &&
+          runtimeType == other.runtimeType &&
+          indexName == other.indexName &&
+          query == other.query &&
+          page == other.page &&
+          hitsPerPage == other.hitsPerPage &&
+          facets.equals(other.facets) &&
+          disjunctiveFacets.equals(other.disjunctiveFacets) &&
+          filterGroups.equals(other.filterGroups) &&
+          ruleContexts.equals(other.ruleContexts) &&
+          facetFilters.equals(other.facetFilters) &&
+          attributesToHighlight.equals(other.attributesToHighlight) &&
+          attributesToRetrieve.equals(other.attributesToRetrieve) &&
+          attributesToSnippet.equals(other.attributesToSnippet) &&
+          highlightPostTag == other.highlightPostTag &&
+          highlightPreTag == other.highlightPreTag &&
+          maxFacetHits == other.maxFacetHits &&
+          maxValuesPerFacet == other.maxValuesPerFacet &&
+          numericFilters.equals(other.numericFilters) &&
+          optionalFilters.equals(other.optionalFilters) &&
+          sumOrFiltersScore == other.sumOrFiltersScore &&
+          tagFilters.equals(other.tagFilters) &&
+          analytics == other.analytics &&
+          userToken == other.userToken &&
+          aroundLatLngViaIP == other.aroundLatLngViaIP &&
+          aroundLatLng == other.aroundLatLng &&
+          aroundRadius == other.aroundRadius &&
+          aroundPrecision == other.aroundPrecision &&
+          minimumAroundRadius == other.minimumAroundRadius;
 
   @override
   int get hashCode =>
@@ -278,6 +278,5 @@ class SearchState {
       'aroundRadius: $aroundRadius, '
       'aroundPrecision: $aroundPrecision, '
       'minimumAroundRadius: $minimumAroundRadius, '
-      '}'
-  ;
+      '}';
 }

--- a/helper_dart/pubspec.lock
+++ b/helper_dart/pubspec.lock
@@ -20,9 +20,10 @@ packages:
   algolia_insights:
     dependency: "direct main"
     description:
-      path: "../insights_dart"
-      relative: true
-    source: path
+      name: algolia_insights
+      sha256: e4c39cd39e39eded3db500bc4fc085e26216f99a6fe3173cc63756f0596a94b3
+      url: "https://pub.dev"
+    source: hosted
     version: "0.1.1"
   analyzer:
     dependency: transitive

--- a/helper_dart/pubspec.yaml
+++ b/helper_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: algolia_helper
 description: Patterns and APIs to implement advanced search features with Algolia
-version: 0.3.1
+version: 0.3.2
 repository: https://github.com/algolia/algoliasearch-helper-flutter/tree/main/helper_dart
 environment:
   sdk: '>=2.17.5 <4.0.0'


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        |no   |
| New feature?    | yes   |
| BC breaks?      | no       |
| Related Issue   | Fix #72  |
| Need Doc update | yes  |

This commit refactors the `SearchState` class to include new properties for location-based search parameters. It also updates the `AlgoliaSearchService` class to handle these new parameters when building queries. The changes include adding support for aroundLatLngViaIP, aroundLatLng, aroundRadius, minimumAroundRadius, and aroundPrecision. 
## What problem is this fixing?

