### PR TITLE
fix(dependency): outdated algolia_helper version in the algolia_helper_flutter pubspec

### DIFF
--- a/helper_flutter/pubspec.yaml
+++ b/helper_flutter/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.17.5 <4.0.0'
   flutter: '>=1.17.0'
 dependencies:
-  algolia_helper: ^0.2.3
+  algolia_helper: ^0.3.1
   flutter:
     sdk: flutter
 dev_dependencies:


### PR DESCRIPTION

| Q               | A        |
|-----------------|----------|
| Bug fix?        | yes   |
| New feature?    | no   |
| BC breaks?      | no       |
| Related Issue   | Fix #80 
| Need Doc update | no   |

## Describe your change

Bumps `algolia_helper` in the `algolia_helper_flutter` to 0.3.1

## What problem is this fixing?

Outdated `algolia_helper` version (0.2.3) in the `algolia_helper_flutter` pubspec.

