### PR TITLE
chore: prepare release 0.3.2

### DIFF
--- a/helper_dart/CHANGELOG.md
+++ b/helper_dart/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## [0.3.2](https://github.com/algolia/algoliasearch-helper-flutter/compare/0.3.1...0.3.2) (2022-05-30)
+
+### Fix
+- Outdated algolia_helper version in the algolia_helper_flutter pubspec
+
 ## [0.3.1](https://github.com/algolia/algoliasearch-helper-flutter/compare/0.3.0...0.3.1) (2022-05-19)
 
 ### Fix

--- a/helper_flutter/CHANGELOG.md
+++ b/helper_flutter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## [0.3.2](https://github.com/algolia/algoliasearch-helper-flutter/compare/0.3.1...0.3.2) (2022-05-30)
+
+### Fix
+- Outdated algolia_helper version in the algolia_helper_flutter pubspec
+
 ## [0.3.1](https://github.com/algolia/algoliasearch-helper-flutter/compare/0.3.0...0.3.1) (2022-05-19)
 
 ### Fix

--- a/helper_flutter/pubspec.yaml
+++ b/helper_flutter/pubspec.yaml
@@ -1,13 +1,13 @@
 name: algolia_helper_flutter
 description: Patterns and APIs to implement advanced search features with Algolia for Flutter
-version: 0.3.1
+version: 0.3.2
 homepage: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/flutter/
 repository: https://github.com/algolia/algoliasearch-helper-flutter/tree/main/helper_flutter
 environment:
   sdk: '>=2.17.5 <4.0.0'
   flutter: '>=1.17.0'
 dependencies:
-  algolia_helper: ^0.3.1
+  algolia_helper: ^0.3.2
   flutter:
     sdk: flutter
 dev_dependencies:


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        | yes   |
| New feature?    | no   |
| BC breaks?      | no       |
| Related Issue   | Fix #... |
| Need Doc update | yes/no   |

## Describe your change

Bump `algolia_helper` version in the `algolia_helper_flutter` pubspec

## What problem is this fixing?

Outdated `algolia_helper` version in the `algolia_helper_flutter` pubspec which causes the outdated `algolia_helper` in the projects using the latest `algolia_helper_flutter`.  
