### PR TITLE
fix(facet): export facet model

### DIFF
--- a/helper/lib/algolia_helper_flutter.dart
+++ b/helper/lib/algolia_helper_flutter.dart
@@ -13,6 +13,7 @@ export 'src/filter_state.dart';
 export 'src/filters.dart';
 export 'src/highlighting.dart';
 export 'src/highlighting_core.dart';
+export 'src/model/facet.dart';
 export 'src/model/multi_search_response.dart';
 export 'src/model/multi_search_state.dart';
 export 'src/searcher/facet_searcher.dart';


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        | yes   |
| New feature?    | no   |
| BC breaks?      | no       |
| Related Issue   | Fix #... |
| Need Doc update | no   |

## Describe your change

<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->
Adds export of `facet.dart` so the `Facet` class is visible to the compiler which allows code with `Facet` type annotation to work.

## What problem is this fixing?

<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->

The `Facet` class wasn't exported which resulted in the compiler not finding it when making type annotations. An example of this would be in the `Getting started` guide in [this section](https://www.algolia.com/doc/guides/building-search-ui/getting-started/flutter/#implement-results-filtering) for `body: StreamBuilder<List<SelectableItem<Facet>>>(`. The code there doesn't compile without the export.