### PR TITLE
fix(facetlist): add missing filter attribute for insights event

### DIFF
--- a/helper/lib/src/facet_list.dart
+++ b/helper/lib/src/facet_list.dart
@@ -308,7 +308,7 @@ class _FacetList with DisposableMixin implements FacetList {
       if (!selections.contains(selection)) {
         eventTracker.clickedFilters(
           eventName: 'Filter Applied',
-          values: [Uri.encodeComponent('$attribute:$selection')],
+          values: [selection],
         );
       }
     });

--- a/helper/lib/src/facet_list.dart
+++ b/helper/lib/src/facet_list.dart
@@ -308,7 +308,7 @@ class _FacetList with DisposableMixin implements FacetList {
       if (!selections.contains(selection)) {
         eventTracker.clickedFilters(
           eventName: 'Filter Applied',
-          values: [selection],
+          values: [Uri.encodeComponent('$attribute:$selection')],
         );
       }
     });

--- a/insights/lib/src/algolia_event_service.dart
+++ b/insights/lib/src/algolia_event_service.dart
@@ -130,6 +130,7 @@ extension AlgoliaEventConversion on Event {
                 .map((val) => Uri.encodeComponent('$attribute:$val'))
                 .toList(),
             userToken: userToken,
+            timestamp: timestamp?.millisecondsSinceEpoch,
           );
         }
         break;

--- a/insights/lib/src/algolia_event_service.dart
+++ b/insights/lib/src/algolia_event_service.dart
@@ -87,7 +87,9 @@ extension AlgoliaEventConversion on Event {
             eventName: eventName,
             eventType: ClickEvent.click,
             index: indexName,
-            filters: filterValues.map((val) => '$attribute:$val').toList(),
+            filters: filterValues
+                .map((val) => Uri.encodeComponent('$attribute:$val'))
+                .toList(),
             userToken: userToken,
             timestamp: timestamp?.millisecondsSinceEpoch,
           );
@@ -124,7 +126,9 @@ extension AlgoliaEventConversion on Event {
             eventName: eventName,
             eventType: ConversionEvent.conversion,
             index: indexName,
-            filters: filterValues.map((val) => '$attribute:$val').toList(),
+            filters: filterValues
+                .map((val) => Uri.encodeComponent('$attribute:$val'))
+                .toList(),
             userToken: userToken,
           );
         }
@@ -147,7 +151,9 @@ extension AlgoliaEventConversion on Event {
             eventName: eventName,
             eventType: ViewEvent.view,
             index: indexName,
-            filters: filterValues.map((val) => '$attribute:$val').toList(),
+            filters: filterValues
+                .map((val) => Uri.encodeComponent('$attribute:$val'))
+                .toList(),
             userToken: userToken,
             timestamp: timestamp?.millisecondsSinceEpoch,
           );

--- a/insights/lib/src/algolia_event_service.dart
+++ b/insights/lib/src/algolia_event_service.dart
@@ -87,7 +87,7 @@ extension AlgoliaEventConversion on Event {
             eventName: eventName,
             eventType: ClickEvent.click,
             index: indexName,
-            filters: filterValues.toList(),
+            filters: filterValues.map((val) => '$attribute:$val').toList(),
             userToken: userToken,
             timestamp: timestamp?.millisecondsSinceEpoch,
           );
@@ -124,7 +124,7 @@ extension AlgoliaEventConversion on Event {
             eventName: eventName,
             eventType: ConversionEvent.conversion,
             index: indexName,
-            filters: filterValues.toList(),
+            filters: filterValues.map((val) => '$attribute:$val').toList(),
             userToken: userToken,
           );
         }
@@ -147,7 +147,7 @@ extension AlgoliaEventConversion on Event {
             eventName: eventName,
             eventType: ViewEvent.view,
             index: indexName,
-            filters: filterValues.toList(),
+            filters: filterValues.map((val) => '$attribute:$val').toList(),
             userToken: userToken,
             timestamp: timestamp?.millisecondsSinceEpoch,
           );

--- a/insights/test/event_test.dart
+++ b/insights/test/event_test.dart
@@ -1,3 +1,5 @@
+import 'package:algolia_client_insights/algolia_client_insights.dart';
+import 'package:algolia_insights/src/algolia_event_service.dart';
 import 'package:algolia_insights/src/event.dart';
 import 'package:test/test.dart';
 
@@ -151,6 +153,154 @@ void main() {
       expect(event.timestamp, equals(timestamp));
       expect(event.attribute, equals(attribute));
       expect(event.filterValues, equals(filterValues));
+    });
+
+    group('Algolia events conversion', () {
+      test('should convert a clickHitsAfterSearch event', () {
+        final event = Event.clickHitsAfterSearch(
+          eventName,
+          indexName,
+          userToken,
+          queryID,
+          objectIDs,
+          positions,
+          timestamp: timestamp,
+        ).toAlgoliaEvent() as ClickedObjectIDsAfterSearch;
+        expect(event.eventType, equals(ClickEvent.click));
+        expect(event.eventName, equals(eventName));
+        expect(event.index, equals(indexName));
+        expect(event.userToken, equals(userToken));
+        expect(event.timestamp, equals(timestamp.millisecondsSinceEpoch));
+        expect(event.queryID, equals(queryID));
+        expect(event.objectIDs, equals(objectIDs));
+        expect(event.positions, equals(positions));
+      });
+
+      test('should convert a clickHits event', () {
+        final event = Event.clickHits(
+          eventName,
+          indexName,
+          userToken,
+          objectIDs,
+          timestamp: timestamp,
+        ).toAlgoliaEvent() as ClickedObjectIDs;
+        expect(event.eventType, equals(ClickEvent.click));
+        expect(event.eventName, equals(eventName));
+        expect(event.index, equals(indexName));
+        expect(event.userToken, equals(userToken));
+        expect(event.timestamp, equals(timestamp.millisecondsSinceEpoch));
+        expect(event.objectIDs, equals(objectIDs));
+      });
+
+      test('should convert a convertHitsAfterSearch event', () {
+        final event = Event.convertHitsAfterSearch(
+          eventName,
+          indexName,
+          userToken,
+          queryID,
+          objectIDs,
+          timestamp: timestamp,
+        ).toAlgoliaEvent() as ConvertedObjectIDsAfterSearch;
+        expect(event.eventType, equals(ConversionEvent.conversion));
+        expect(event.eventName, equals(eventName));
+        expect(event.index, equals(indexName));
+        expect(event.userToken, equals(userToken));
+        expect(event.timestamp, equals(timestamp.millisecondsSinceEpoch));
+        expect(event.queryID, equals(queryID));
+        expect(event.objectIDs, equals(objectIDs));
+      });
+
+      test('should convert a convertHits event', () {
+        final event = Event.convertHits(
+          eventName,
+          indexName,
+          userToken,
+          objectIDs,
+          timestamp: timestamp,
+        ).toAlgoliaEvent() as ConvertedObjectIDs;
+        expect(event.eventType, equals(ConversionEvent.conversion));
+        expect(event.eventName, equals(eventName));
+        expect(event.index, equals(indexName));
+        expect(event.userToken, equals(userToken));
+        expect(event.timestamp, equals(timestamp.millisecondsSinceEpoch));
+        expect(event.objectIDs, equals(objectIDs));
+      });
+
+      test('should convert a viewHits event', () {
+        final event = Event.viewHits(
+          eventName,
+          indexName,
+          userToken,
+          objectIDs,
+          timestamp: timestamp,
+        ).toAlgoliaEvent() as ViewedObjectIDs;
+        expect(event.eventType, equals(ViewEvent.view));
+        expect(event.eventName, equals(eventName));
+        expect(event.index, equals(indexName));
+        expect(event.userToken, equals(userToken));
+        expect(event.timestamp, equals(timestamp.millisecondsSinceEpoch));
+        expect(event.objectIDs, equals(objectIDs));
+      });
+
+      test('should convert a clickFilters event', () {
+        final event = Event.clickFilters(
+          eventName,
+          indexName,
+          userToken,
+          attribute,
+          filterValues,
+          timestamp: timestamp,
+        ).toAlgoliaEvent() as ClickedFilters;
+        expect(event.eventType, equals(ClickEvent.click));
+        expect(event.eventName, equals(eventName));
+        expect(event.index, equals(indexName));
+        expect(event.userToken, equals(userToken));
+        expect(event.timestamp, equals(timestamp.millisecondsSinceEpoch));
+        expect(
+          event.filters,
+          equals(filterValues.map((v) => Uri.encodeComponent('$attribute:$v'))),
+        );
+      });
+
+      test('should convert a viewFilters event', () {
+        final event = Event.viewFilters(
+          eventName,
+          indexName,
+          userToken,
+          attribute,
+          filterValues,
+          timestamp: timestamp,
+        ).toAlgoliaEvent() as ViewedFilters;
+        expect(event.eventType, equals(ViewEvent.view));
+        expect(event.eventName, equals(eventName));
+        expect(event.index, equals(indexName));
+        expect(event.userToken, equals(userToken));
+        expect(event.timestamp, equals(timestamp.millisecondsSinceEpoch));
+        expect(
+          event.filters,
+          equals(filterValues.map((v) => Uri.encodeComponent('$attribute:$v'))),
+        );
+      });
+
+      test('should convert a convertFilters event', () {
+        final event = Event.convertFilters(
+          eventName,
+          indexName,
+          userToken,
+          attribute,
+          filterValues,
+          timestamp: timestamp,
+        ).toAlgoliaEvent() as ConvertedFilters;
+        expect(event.eventType, equals(ConversionEvent.conversion));
+        expect(event.eventName, equals(eventName));
+        expect(event.index, equals(indexName));
+        expect(event.userToken, equals(userToken));
+        expect(event.timestamp, equals(timestamp.millisecondsSinceEpoch));
+        expect(
+          event.filters,
+          equals(filterValues.map((v) => Uri.encodeComponent('$attribute:$v'))),
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        | yes   |
| New feature?    | no   |
| BC breaks?      | no       |
| Related Issue   | Fix #108  |
| Need Doc update | no   |

## Describe your change

Add missing filter attribute for Insights click event in the FacetList

## What problem is this fixing?

Exception thrown due to wrong `filter` value.