### PR TITLE
fix(HitsSearcher): non-initialized EventTracker

### DIFF
--- a/helper/lib/src/searcher/hits_searcher.dart
+++ b/helper/lib/src/searcher/hits_searcher.dart
@@ -257,7 +257,7 @@ class _HitsSearcher with DisposableMixin implements HitsSearcher {
   final HitsSearchService searchService;
 
   @override
-  late final HitsEventTracker? eventTracker;
+  HitsEventTracker? eventTracker;
 
   /// Search state debounce duration
   final Duration debounce;

--- a/helper/test/facet_list_test.dart
+++ b/helper/test/facet_list_test.dart
@@ -152,6 +152,31 @@ void main() {
         ),
       );
     });
+
+    test('Build FacetList without EventTracker', () {
+      final searcher = HitsSearcher.custom(
+        MockHitsSearchService(),
+        null,
+        const SearchState(indexName: 'myIndex'),
+      );
+
+      final filterState = FilterState();
+
+      // Create a disjunctive FacetList
+      searcher.buildFacetList(
+        filterState: filterState,
+        attribute: 'color',
+      );
+
+      expect(
+        searcher.snapshot(),
+        const SearchState(
+          indexName: 'myIndex',
+          facets: ['color'],
+          disjunctiveFacets: {'color'},
+        ),
+      );
+    });
   });
 
   group('Update filter state', () {


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        | yes   |
| New feature?    | no   |
| BC breaks?      | no       |
| Related Issue   | Fix #124 |
| Need Doc update | no   |

## Describe your change

I removed the restriction to define the EventTracker and added an unit test to cover that case

## What problem is this fixing?

esentially when you need to initialize the FacetList the getter breaks the code, however, looking in the code is expected the null value.
