### PR TITLE
feat(searcher): add client options

### DIFF
--- a/helper/lib/algolia_helper_flutter.dart
+++ b/helper/lib/algolia_helper_flutter.dart
@@ -4,6 +4,7 @@
 /// experiences at a deeper level for Flutter framework.
 library algolia_helper_flutter;
 
+export 'src/client_options.dart';
 export 'src/disposable.dart';
 export 'src/exception.dart';
 export 'src/facet_list.dart';

--- a/helper/lib/src/client_options.dart
+++ b/helper/lib/src/client_options.dart
@@ -1,0 +1,30 @@
+/// Configuration options for the HTTP client.
+final class ClientOptions {
+  /// The maximum duration to wait for a connection to establish before timing out.
+  final Duration? connectTimeout;
+
+  /// The maximum duration to wait for a write operation to complete before timing out.
+  final Duration? writeTimeout;
+
+  /// The maximum duration to wait for a read operation to complete before timing out.
+  final Duration? readTimeout;
+
+  /// Default headers to include in each HTTP request.
+  final Map<String, dynamic>? headers;
+
+  /// Custom logger for http operations.
+  final Function(Object?)? logger;
+
+  const ClientOptions({
+    this.connectTimeout,
+    this.writeTimeout,
+    this.readTimeout,
+    this.headers,
+    this.logger,
+  });
+
+  @override
+  String toString() {
+    return 'ClientOptions{connectTimeout: $connectTimeout, writeTimeout: $writeTimeout, readTimeout: $readTimeout, headers: $headers, logger: $logger}';
+  }
+}

--- a/helper/lib/src/searcher/hits_searcher.dart
+++ b/helper/lib/src/searcher/hits_searcher.dart
@@ -5,6 +5,7 @@ import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 
+import '../client_options.dart';
 import '../disposable.dart';
 import '../disposable_mixin.dart';
 import '../filter_state.dart';
@@ -103,6 +104,7 @@ abstract interface class HitsSearcher implements Disposable, EventDataDelegate {
     bool disjunctiveFacetingEnabled = true,
     Duration debounce = const Duration(milliseconds: 100),
     bool insights = false,
+    ClientOptions? options,
   }) =>
       _HitsSearcher(
         applicationID: applicationID,
@@ -114,6 +116,7 @@ abstract interface class HitsSearcher implements Disposable, EventDataDelegate {
         ),
         debounce: debounce,
         insights: insights,
+        options: options,
       );
 
   /// HitsSearcher's factory.
@@ -124,6 +127,7 @@ abstract interface class HitsSearcher implements Disposable, EventDataDelegate {
     bool disjunctiveFacetingEnabled = true,
     Duration debounce = const Duration(milliseconds: 100),
     bool insights = false,
+    ClientOptions? options,
   }) =>
       _HitsSearcher(
         applicationID: applicationID,
@@ -132,6 +136,7 @@ abstract interface class HitsSearcher implements Disposable, EventDataDelegate {
         disjunctiveFacetingEnabled: disjunctiveFacetingEnabled,
         debounce: debounce,
         insights: insights,
+        options: options,
       );
 
   /// Creates [HitsSearcher] using a custom [HitsSearchService].
@@ -194,10 +199,12 @@ final class _HitsSearcher with DisposableMixin implements HitsSearcher {
     bool disjunctiveFacetingEnabled = true,
     Duration debounce = const Duration(milliseconds: 100),
     bool insights = false,
+    ClientOptions? options,
   }) {
     final service = AlgoliaHitsSearchService(
       applicationID: applicationID,
       apiKey: apiKey,
+      options: options,
     );
 
     EventTracker? eventTracker;

--- a/helper/lib/src/service/algolia_hits_search_service.dart
+++ b/helper/lib/src/service/algolia_hits_search_service.dart
@@ -1,6 +1,7 @@
 import 'package:algoliasearch/algoliasearch.dart' as algolia;
 import 'package:logging/logging.dart';
 
+import '../client_options.dart';
 import '../lib_version.dart';
 import '../logger.dart';
 import '../model/multi_search_response.dart';
@@ -14,20 +15,31 @@ class AlgoliaHitsSearchService implements HitsSearchService {
   AlgoliaHitsSearchService({
     required String applicationID,
     required String apiKey,
+    ClientOptions? options,
   }) : this.create(
           algolia.SearchClient(
             appId: applicationID,
             apiKey: apiKey,
-            options: const algolia.ClientOptions(
-              agentSegments: [
-                algolia.AgentSegment(
-                  value: 'algolia-helper-flutter',
-                  version: libVersion,
-                ),
-              ],
-            ),
+            options: _createClientOptions(options),
           ),
         );
+
+  /// Create [algolia.ClientOptions] instance.
+  static algolia.ClientOptions _createClientOptions(ClientOptions? options) {
+    return algolia.ClientOptions(
+      connectTimeout: options?.connectTimeout ?? const Duration(seconds: 2),
+      writeTimeout: options?.writeTimeout ?? const Duration(seconds: 30),
+      readTimeout: options?.readTimeout ?? const Duration(seconds: 5),
+      headers: options?.headers,
+      logger: options?.logger,
+      agentSegments: [
+        algolia.AgentSegment(
+          value: 'algolia-helper-flutter',
+          version: libVersion,
+        ),
+      ],
+    );
+  }
 
   /// Creates [HitsSearchService] instance.
   AlgoliaHitsSearchService.create(


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        | no   |
| New feature?    | no   |
| BC breaks?      | no       |
| Related Issue   | CR-5915 |
| Need Doc update | no   |

## Describe your change

Add `ClientOptions` parameter, enabling HTTP client configuration.
