### PR TITLE
feat(searcher): add `ClientOptions` to `MultiSearcher` and `FacetSearcher`

### DIFF
--- a/helper/example/facet_list.dart
+++ b/helper/example/facet_list.dart
@@ -11,12 +11,13 @@ void main() {
     apiKey: '1f6fd3a6fb973cb08419fe7d288fa4db',
     indexName: 'instant_search',
   )
-  // Create a connection between the searcher and the filter state
+    // Create a connection between the searcher and the filter state
     ..connectFilterState(filterState);
 
   // Create facet list components that displays facets, and lets the user refine
   // their search results by filtering on specific values.
-  final facetList = searcher.buildFacetList(filterState: filterState, attribute: 'brand');
+  final facetList =
+      searcher.buildFacetList(filterState: filterState, attribute: 'brand');
 
   // Listen to facet lists with selection status.
   facetList.facets.listen((facets) {

--- a/helper/example/facet_list_app.dart
+++ b/helper/example/facet_list_app.dart
@@ -11,16 +11,16 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => MaterialApp(
-    title: 'Algolia Helpers for Flutter',
-    theme: ThemeData(
-      primarySwatch: Colors.blue,
-    ),
-    home: Provider<SearchController>(
-      create: (_) => SearchController(),
-      dispose: (_, value) => value.dispose(),
-      child: const MyHomePage(),
-    ),
-  );
+        title: 'Algolia Helpers for Flutter',
+        theme: ThemeData(
+          primarySwatch: Colors.blue,
+        ),
+        home: Provider<SearchController>(
+          create: (_) => SearchController(),
+          dispose: (_, value) => value.dispose(),
+          child: const MyHomePage(),
+        ),
+      );
 }
 
 class SearchController {
@@ -33,7 +33,7 @@ class SearchController {
     apiKey: '1f6fd3a6fb973cb08419fe7d288fa4db',
     indexName: 'instant_search',
   )
-  // 2.2. Create a connection between the searcher and the filter state
+    // 2.2. Create a connection between the searcher and the filter state
     ..connectFilterState(filterState);
 
   // 3. Create facet list (refinement list) component.
@@ -103,7 +103,7 @@ class _MyHomePageState extends State<MyHomePage> {
                       text: TextSpan(
                         style: Theme.of(context).textTheme.titleSmall,
                         children:
-                        hit.getHighlightedString('name').toInlineSpans(),
+                            hit.getHighlightedString('name').toInlineSpans(),
                       ),
                     ),
                   );
@@ -151,7 +151,7 @@ class _FiltersPageState extends State<FiltersPage> {
                 return ListTile(
                   title: Text(
                     '${facet.value} '
-                        "${facet.count > 0 ? '(${facet.count})' : ''} ",
+                    "${facet.count > 0 ? '(${facet.count})' : ''} ",
                   ),
                   trailing: model.isSelected ? const Icon(Icons.check) : null,
                   onTap: () {

--- a/helper/lib/src/searcher/facet_searcher.dart
+++ b/helper/lib/src/searcher/facet_searcher.dart
@@ -2,6 +2,7 @@ import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 
+import '../client_options.dart';
 import '../disposable.dart';
 import '../disposable_mixin.dart';
 import '../logger.dart';
@@ -106,6 +107,7 @@ abstract interface class FacetSearcher implements Disposable {
     required String indexName,
     required String facet,
     Duration debounce = const Duration(milliseconds: 100),
+    ClientOptions? options,
   }) =>
       _FacetSearcher(
         applicationID: applicationID,
@@ -115,6 +117,7 @@ abstract interface class FacetSearcher implements Disposable {
           facet: facet,
         ),
         debounce: debounce,
+        options: options,
       );
 
   /// HitsSearcher's factory.
@@ -123,12 +126,14 @@ abstract interface class FacetSearcher implements Disposable {
     required String apiKey,
     required FacetSearchState state,
     Duration debounce = const Duration(milliseconds: 100),
+    ClientOptions? options,
   }) =>
       _FacetSearcher(
         applicationID: applicationID,
         apiKey: apiKey,
         state: state,
         debounce: debounce,
+        options: options,
       );
 
   /// Creates [FacetSearcher] using a custom [FacetSearchService].
@@ -170,10 +175,12 @@ class _FacetSearcher with DisposableMixin implements FacetSearcher {
     required String apiKey,
     required FacetSearchState state,
     Duration debounce = const Duration(milliseconds: 100),
+    ClientOptions? options,
   }) {
     final service = AlgoliaFacetSearchService(
       applicationID: applicationID,
       apiKey: apiKey,
+      options: options,
     );
     return _FacetSearcher.create(
       service,

--- a/helper/lib/src/searcher/multi_searcher.dart
+++ b/helper/lib/src/searcher/multi_searcher.dart
@@ -5,6 +5,7 @@ import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 
+import '../client_options.dart';
 import '../disposable.dart';
 import '../disposable_mixin.dart';
 import '../logger.dart';
@@ -89,12 +90,14 @@ abstract interface class MultiSearcher implements Disposable {
     required String apiKey,
     EventTracker? eventTracker,
     Duration debounce = const Duration(milliseconds: 100),
+    ClientOptions? options,
   }) =>
       _MultiSearcher(
         applicationID: applicationID,
         apiKey: apiKey,
         eventTracker: eventTracker,
         debounce: debounce,
+        options: options,
       );
 
   /// Creates [MultiSearcher] using a custom [MultiSearchService] and
@@ -141,10 +144,12 @@ class _MultiSearcher with DisposableMixin implements MultiSearcher {
     required String apiKey,
     EventTracker? eventTracker,
     Duration debounce = const Duration(milliseconds: 100),
+    ClientOptions? options,
   }) {
     final service = AlgoliaMultiSearchService(
       applicationID: applicationID,
       apiKey: apiKey,
+      options: options,
     );
     final actualEventTracker = eventTracker ??
         Insights(

--- a/helper/lib/src/service/algolia_facet_search_service.dart
+++ b/helper/lib/src/service/algolia_facet_search_service.dart
@@ -1,11 +1,12 @@
 import 'package:algoliasearch/algoliasearch.dart' as algolia;
 import 'package:logging/logging.dart';
 
-import '../lib_version.dart';
+import '../client_options.dart';
 import '../logger.dart';
 import '../model/multi_search_response.dart';
 import '../model/multi_search_state.dart';
 import 'algolia_client_extensions.dart';
+import 'client_options.dart';
 import 'facet_search_service.dart';
 
 class AlgoliaFacetSearchService implements FacetSearchService {
@@ -13,20 +14,12 @@ class AlgoliaFacetSearchService implements FacetSearchService {
   AlgoliaFacetSearchService({
     required String applicationID,
     required String apiKey,
-  }) : this.create(
-          algolia.SearchClient(
-            appId: applicationID,
-            apiKey: apiKey,
-            options: const algolia.ClientOptions(
-              agentSegments: [
-                algolia.AgentSegment(
-                  value: 'algolia-helper-flutter',
-                  version: libVersion,
-                ),
-              ],
-            ),
-          ),
-        );
+    ClientOptions? options,
+  }) : this.create(algolia.SearchClient(
+          appId: applicationID,
+          apiKey: apiKey,
+          options: createClientOptions(options),
+        ));
 
   /// Creates [AlgoliaFacetSearchService] instance.
   AlgoliaFacetSearchService.create(

--- a/helper/lib/src/service/algolia_hits_search_service.dart
+++ b/helper/lib/src/service/algolia_hits_search_service.dart
@@ -2,12 +2,12 @@ import 'package:algoliasearch/algoliasearch.dart' as algolia;
 import 'package:logging/logging.dart';
 
 import '../client_options.dart';
-import '../lib_version.dart';
 import '../logger.dart';
 import '../model/multi_search_response.dart';
 import '../model/multi_search_state.dart';
 import '../query_builder.dart';
 import 'algolia_client_extensions.dart';
+import 'client_options.dart';
 import 'hits_search_service.dart';
 
 class AlgoliaHitsSearchService implements HitsSearchService {
@@ -20,26 +20,9 @@ class AlgoliaHitsSearchService implements HitsSearchService {
           algolia.SearchClient(
             appId: applicationID,
             apiKey: apiKey,
-            options: _createClientOptions(options),
+            options: createClientOptions(options),
           ),
         );
-
-  /// Create [algolia.ClientOptions] instance.
-  static algolia.ClientOptions _createClientOptions(ClientOptions? options) {
-    return algolia.ClientOptions(
-      connectTimeout: options?.connectTimeout ?? const Duration(seconds: 2),
-      writeTimeout: options?.writeTimeout ?? const Duration(seconds: 30),
-      readTimeout: options?.readTimeout ?? const Duration(seconds: 5),
-      headers: options?.headers,
-      logger: options?.logger,
-      agentSegments: [
-        algolia.AgentSegment(
-          value: 'algolia-helper-flutter',
-          version: libVersion,
-        ),
-      ],
-    );
-  }
 
   /// Creates [HitsSearchService] instance.
   AlgoliaHitsSearchService.create(

--- a/helper/lib/src/service/algolia_multi_search_service.dart
+++ b/helper/lib/src/service/algolia_multi_search_service.dart
@@ -1,7 +1,7 @@
 import 'package:algoliasearch/algoliasearch.dart' as algolia;
 import 'package:logging/logging.dart';
 
-import '../../algolia_helper_flutter.dart';
+import '../client_options.dart';
 import '../logger.dart';
 import '../multi_search_state_folder.dart';
 import 'algolia_client_extensions.dart';

--- a/helper/lib/src/service/algolia_multi_search_service.dart
+++ b/helper/lib/src/service/algolia_multi_search_service.dart
@@ -1,12 +1,11 @@
 import 'package:algoliasearch/algoliasearch.dart' as algolia;
 import 'package:logging/logging.dart';
 
-import '../lib_version.dart';
+import '../../algolia_helper_flutter.dart';
 import '../logger.dart';
-import '../model/multi_search_response.dart';
-import '../model/multi_search_state.dart';
 import '../multi_search_state_folder.dart';
 import 'algolia_client_extensions.dart';
+import 'client_options.dart';
 import 'multi_search_service.dart';
 
 final class AlgoliaMultiSearchService extends MultiSearchService {
@@ -19,18 +18,12 @@ final class AlgoliaMultiSearchService extends MultiSearchService {
   AlgoliaMultiSearchService({
     required String applicationID,
     required String apiKey,
+    ClientOptions? options,
   }) : this.create(
           algolia.SearchClient(
             appId: applicationID,
             apiKey: apiKey,
-            options: const algolia.ClientOptions(
-              agentSegments: [
-                algolia.AgentSegment(
-                  value: 'algolia-helper-flutter',
-                  version: libVersion,
-                ),
-              ],
-            ),
+            options: createClientOptions(options),
           ),
         );
 

--- a/helper/lib/src/service/algolia_multi_search_service.dart
+++ b/helper/lib/src/service/algolia_multi_search_service.dart
@@ -3,6 +3,8 @@ import 'package:logging/logging.dart';
 
 import '../client_options.dart';
 import '../logger.dart';
+import '../model/multi_search_response.dart';
+import '../model/multi_search_state.dart';
 import '../multi_search_state_folder.dart';
 import 'algolia_client_extensions.dart';
 import 'client_options.dart';

--- a/helper/lib/src/service/client_options.dart
+++ b/helper/lib/src/service/client_options.dart
@@ -1,0 +1,21 @@
+import 'package:algoliasearch/algoliasearch.dart' as algolia;
+
+import '../client_options.dart';
+import '../lib_version.dart';
+
+/// Create [algolia.ClientOptions] instance.
+algolia.ClientOptions createClientOptions(ClientOptions? options) {
+  return algolia.ClientOptions(
+    connectTimeout: options?.connectTimeout ?? const Duration(seconds: 2),
+    writeTimeout: options?.writeTimeout ?? const Duration(seconds: 30),
+    readTimeout: options?.readTimeout ?? const Duration(seconds: 5),
+    headers: options?.headers,
+    logger: options?.logger,
+    agentSegments: [
+      algolia.AgentSegment(
+        value: 'algolia-helper-flutter',
+        version: libVersion,
+      ),
+    ],
+  );
+}


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        | no   |
| New feature?    | no   |
| BC breaks?      | no       |
| Related Issue   | n/a |
| Need Doc update | no   |

## Describe your change

[#131](https://github.com/algolia/algoliasearch-helper-flutter/pull/131) adds `ClientOptions`  to `HitsSearcher`.
In this PR we add `ClientOptions` to `MultiSearcher` and `FacetSearcher`
