### PR TITLE
ci: use downgrade-safe method to dispose of subscriptions

### DIFF
--- a/helper/lib/src/facet_list.dart
+++ b/helper/lib/src/facet_list.dart
@@ -294,6 +294,6 @@ final class _FacetList with DisposableMixin implements FacetList {
   void doDispose() {
     _log.finest('FacetList disposed');
     _sequencer.dispose();
-    _subscriptions.cancel();
+    _subscriptions.dispose();
   }
 }

--- a/helper/lib/src/searcher/facet_searcher.dart
+++ b/helper/lib/src/searcher/facet_searcher.dart
@@ -286,6 +286,6 @@ class _FacetSearcher with DisposableMixin implements FacetSearcher {
   void doDispose() {
     _log.fine('FacetSearcher disposed');
     _request.close();
-    _subscriptions.cancel();
+    _subscriptions.dispose();
   }
 }

--- a/helper/lib/src/searcher/hits_searcher.dart
+++ b/helper/lib/src/searcher/hits_searcher.dart
@@ -336,7 +336,7 @@ final class _HitsSearcher with DisposableMixin implements HitsSearcher {
   void doDispose() {
     _log.fine('HitsSearcher disposed');
     _request.close();
-    _subscriptions.cancel();
+    _subscriptions.dispose();
   }
 
   @override


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        |     no   |
| New feature?    |     no   |
| BC breaks?      | no       |
| Related Issue   |          |
| Need Doc update |     no   |

## Describe your change

This PR calls `dispose()` instead of `cancel()` on CompositeSubscriptions, to pass pana checks during CI.

## What problem is this fixing?

pana checks for issues when dependencies are using downgraded versions, and in this case fails the check for the following reasons:

```
[algolia_helper_flutter]:  - `UNDEFINED_METHOD` - `lib/src/facet_list.dart:297:20` - The method 'cancel' isn't defined for the type 'CompositeSubscription'.
[algolia_helper_flutter]:  - `UNDEFINED_METHOD` - `lib/src/searcher/facet_searcher.dart:289:20` - The method 'cancel' isn't defined for the type 'CompositeSubscription'.
[algolia_helper_flutter]:  - `UNDEFINED_METHOD` - `lib/src/searcher/hits_searcher.dart:339:20` - The method 'cancel' isn't defined for the type 'CompositeSubscription'.
```

This should have no impact on code as `cancel()` itself [indirectly calls `dispose()`](https://github.com/ReactiveX/rxdart/blob/master/packages/rxdart/lib/src/utils/composite_subscription.dart#L89).
