### PR TITLE
chore: update melos and change linked insights version notation

### DIFF
--- a/helper/pubspec.yaml
+++ b/helper/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
   flutter: '>=1.17.0'
 dependencies:
-  algolia_insights: ">=1.0.0 <2.0.0"
+  algolia_insights: ^1.0.0
   algoliasearch: ">=1.3.0 <2.0.0"
   collection: ">=1.17.0 <2.0.0"
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,4 +3,4 @@ name: algolia_helper_workspace
 environment:
   sdk: ">=3.0.0 <4.0.0"
 dev_dependencies:
-  melos: ^3.4.0
+  melos: ^6.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,4 +3,5 @@ name: algolia_helper_workspace
 environment:
   sdk: ">=3.0.0 <4.0.0"
 dev_dependencies:
+  lints: ^4.0.0
   melos: ^6.1.0


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        | no   |
| New feature?    | no   |
| BC breaks?      | no       |
| Related Issue   |  |
| Need Doc update | no   |

## Describe your change

This PR updates melos to the latest version and changes how algolia_insights is constrained in algolia_helper_flutter's dependency file. The constraint is the same, but the updated notation does not cause issues with `melos version` anymore.
