### PR TITLE
ci: publish helper after insights

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,17 +23,6 @@ jobs:
         run: melos get
       - name: Run tests
         run: melos test --no-select
-
-
-  publish-helper:
-    if: ${{ contains(github.ref, 'helper') }}
-    needs:
-      - check
-    permissions:
-      id-token: write
-    uses: dart-lang/setup-dart/.github/workflows/publish.yaml@v1
-    with:
-      working-directory: helper
   
   publish-insights:
     if: ${{ contains(github.ref, 'insights') }}
@@ -41,6 +30,29 @@ jobs:
       - check
     permissions:
       id-token: write
-    uses: dart-lang/setup-dart/.github/workflows/publish.yaml@v1
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:
       working-directory: insights
+
+  # Helps insights get published first to prevent
+  # the helper being penalized by pub.dev's scoring system
+  delay-publish-helper:
+    if: ${{ contains(github.ref, 'helper') }}
+    runs-on: ubuntu-latest
+    needs:
+      - check
+    steps:
+      - name: Wait for 30 seconds
+        run: sleep 30s
+        shell: bash
+
+  publish-helper:
+    if: ${{ contains(github.ref, 'helper') }}
+    needs:
+      - check
+      - delay-publish-helper
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      working-directory: helper


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        | no   |
| New feature?    | no   |
| BC breaks?      | no       |
| Related Issue   | Fix #... |
| Need Doc update | no   |

## Describe your change

This PR:

- updates the dart action path to work properly
- delays publishing the helper in order to give more time for the insights package to be on pub.dev
