### PR TITLE
feat(clientOption): enable pass interceptor as parameters

### DIFF
--- a/helper/lib/src/client_options.dart
+++ b/helper/lib/src/client_options.dart
@@ -1,3 +1,5 @@
+import 'package:dio/dio.dart';
+
 /// Configuration options for the HTTP client.
 final class ClientOptions {
   /// The maximum duration to wait for a connection to establish before timing out.
@@ -15,16 +17,21 @@ final class ClientOptions {
   /// Custom logger for http operations.
   final Function(Object?)? logger;
 
+  /// List of Dio interceptors.
+  /// Used only in case of using the default (dio) requester.
+  final Iterable<Interceptor>? interceptors;
+
   const ClientOptions({
     this.connectTimeout,
     this.writeTimeout,
     this.readTimeout,
     this.headers,
     this.logger,
+    this.interceptors,
   });
 
   @override
   String toString() {
-    return 'ClientOptions{connectTimeout: $connectTimeout, writeTimeout: $writeTimeout, readTimeout: $readTimeout, headers: $headers, logger: $logger}';
+    return 'ClientOptions{connectTimeout: $connectTimeout, writeTimeout: $writeTimeout, readTimeout: $readTimeout, headers: $headers, logger: $logger, interceptors: $interceptors}';
   }
 }

--- a/helper/lib/src/service/client_options.dart
+++ b/helper/lib/src/service/client_options.dart
@@ -11,6 +11,7 @@ algolia.ClientOptions createClientOptions(ClientOptions? options) {
     readTimeout: options?.readTimeout ?? const Duration(seconds: 5),
     headers: options?.headers,
     logger: options?.logger,
+    interceptors: options?.interceptors,
     agentSegments: [
       algolia.AgentSegment(
         value: 'algolia-helper-flutter',


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        | no   |
| New feature?    | yes   |
| BC breaks?      | no       |
| Related Issue   | Fix #148  |
| Need Doc update | no   |

## Describe your change

This change enable to pass a custom interceptor do ClientOptions

## What problem is this fixing?

This way I be enabled to create my own interceptor as CacheInterceptor