### PR TITLE
fix(client): remove invalid `maxFacetHits` in `SearchForHits` extension

### DIFF
--- a/helper/lib/src/filter_group_converter.dart
+++ b/helper/lib/src/filter_group_converter.dart
@@ -89,6 +89,7 @@ final class FilterConverter {
           filter.attribute,
           filter.isNegated,
         );
+      // ignore: unreachable_switch_default
       default:
         throw ArgumentError('Filter type ${filter.runtimeType} not supported');
     }

--- a/helper/lib/src/service/algolia_client_extensions.dart
+++ b/helper/lib/src/service/algolia_client_extensions.dart
@@ -38,7 +38,6 @@ extension AlgolisSearchStateExt on SearchState {
       highlightPostTag: highlightPostTag,
       highlightPreTag: highlightPreTag,
       hitsPerPage: hitsPerPage,
-      maxFacetHits: maxFacetHits,
       maxValuesPerFacet: maxValuesPerFacet,
       numericFilters: numericFilters,
       optionalFilters: optionalFilters,

--- a/helper/test/filter_converter_test.dart
+++ b/helper/test/filter_converter_test.dart
@@ -10,11 +10,11 @@ void main() {
       final filterScore = Filter.facet('attributeA', true, score: 4);
 
       const converter = FilterConverter();
-      expect(converter.sql(filterTrue), '\"attributeA\":true');
-      expect(converter.sql(filterFalse), '\"attributeA\":false');
-      expect(converter.sql(filterTrue.not()), 'NOT \"attributeA\":true');
-      expect(converter.sql(filterFalse.not()), 'NOT \"attributeA\":false');
-      expect(converter.sql(filterScore), '\"attributeA\":true<score=4>');
+      expect(converter.sql(filterTrue), '"attributeA":true');
+      expect(converter.sql(filterFalse), '"attributeA":false');
+      expect(converter.sql(filterTrue.not()), 'NOT "attributeA":true');
+      expect(converter.sql(filterFalse.not()), 'NOT "attributeA":false');
+      expect(converter.sql(filterScore), '"attributeA":true<score=4>');
     });
 
     test('Filter facet Number', () {
@@ -23,11 +23,11 @@ void main() {
       final filterScore = Filter.facet('attributeA', 1, score: 2);
 
       const converter = FilterConverter();
-      expect(converter.sql(filterInt), '\"attributeA\":1');
-      expect(converter.sql(filterDouble), '\"attributeA\":${1.0}');
-      expect(converter.sql(filterDouble.not()), 'NOT \"attributeA\":${1.0}');
-      expect(converter.sql(filterScore), '\"attributeA\":1<score=2>');
-      expect(converter.sql(filterScore), '\"attributeA\":1<score=2>');
+      expect(converter.sql(filterInt), '"attributeA":1');
+      expect(converter.sql(filterDouble), '"attributeA":${1.0}');
+      expect(converter.sql(filterDouble.not()), 'NOT "attributeA":${1.0}');
+      expect(converter.sql(filterScore), '"attributeA":1<score=2>');
+      expect(converter.sql(filterScore), '"attributeA":1<score=2>');
     });
 
     test('Filter facet String', () {
@@ -37,15 +37,15 @@ void main() {
       final filterScore = Filter.facet('attributeA', 'valueA', score: 1);
 
       const converter = FilterConverter();
-      expect(converter.sql(filter), '\"attributeA\":\"valueA\"');
-      expect(converter.sql(filterNegate), 'NOT \"attributeA\":\"valueA\"');
+      expect(converter.sql(filter), '"attributeA":"valueA"');
+      expect(converter.sql(filterNegate), 'NOT "attributeA":"valueA"');
       expect(
         converter.sql(filterSpace),
-        '\"attributeA\":\"value with space\"',
+        '"attributeA":"value with space"',
       );
       expect(
         converter.sql(filterScore),
-        '\"attributeA\":\"valueA\"<score=1>',
+        '"attributeA":"valueA"<score=1>',
       );
     });
   });
@@ -64,13 +64,13 @@ void main() {
           Filter.comparison('attributeA', NumericOperator.greaterOrEquals, 5);
 
       const converter = FilterConverter();
-      expect(converter.sql(less), '\"attributeA\" < 5');
-      expect(converter.sql(lessOrEquals), '\"attributeA\" <= 5');
-      expect(converter.sql(equals), '\"attributeA\" = 5');
-      expect(converter.sql(notEquals), '\"attributeA\" != 5');
-      expect(converter.sql(greater), '\"attributeA\" > 5');
-      expect(converter.sql(greaterOrEquals), '\"attributeA\" >= 5');
-      expect(converter.sql(less.not()), 'NOT \"attributeA\" < 5');
+      expect(converter.sql(less), '"attributeA" < 5');
+      expect(converter.sql(lessOrEquals), '"attributeA" <= 5');
+      expect(converter.sql(equals), '"attributeA" = 5');
+      expect(converter.sql(notEquals), '"attributeA" != 5');
+      expect(converter.sql(greater), '"attributeA" > 5');
+      expect(converter.sql(greaterOrEquals), '"attributeA" >= 5');
+      expect(converter.sql(less.not()), 'NOT "attributeA" < 5');
     });
 
     test('Filter numeric range', () {
@@ -80,17 +80,17 @@ void main() {
           Filter.range('attributeA', lowerBound: 0.0, upperBound: 6.0);
 
       const converter = FilterConverter();
-      expect(converter.sql(filterInt), '\"attributeA\":0 TO 6');
-      expect(converter.sql(filterDouble), '\"attributeA\":${0.0} TO ${6.0}');
-      expect(converter.sql(filterInt.not()), 'NOT \"attributeA\":0 TO 6');
+      expect(converter.sql(filterInt), '"attributeA":0 TO 6');
+      expect(converter.sql(filterDouble), '"attributeA":${0.0} TO ${6.0}');
+      expect(converter.sql(filterInt.not()), 'NOT "attributeA":0 TO 6');
     });
   });
 
   test('Filter tag SQL', () {
     final filter = Filter.tag('valueA');
     const converter = FilterConverter();
-    expect(converter.sql(filter), '_tags:\"valueA\"');
-    expect(converter.sql(filter.not()), 'NOT _tags:\"valueA\"');
+    expect(converter.sql(filter), '_tags:"valueA"');
+    expect(converter.sql(filter.not()), 'NOT _tags:"valueA"');
   });
 
   group('Filter group SQL', () {

--- a/insights/lib/src/algolia_event_service.dart
+++ b/insights/lib/src/algolia_event_service.dart
@@ -1,5 +1,4 @@
 import 'package:algolia_client_insights/algolia_client_insights.dart';
-import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 
 import 'event.dart';
@@ -42,8 +41,8 @@ class AlgoliaEventService implements EventService {
   void send(List<Event> events) => _client
       .pushEvents(
         insightsEvents: InsightsEvents(
-          events: events.map((e) => e.toAlgoliaEvent()).whereNotNull(),
-        ),
+            events:
+                events.map((e) => e.toAlgoliaEvent()).where((e) => e != null)),
       )
       .then(
         (_) => _log.fine('Events upload: $events'),


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        | yes      |
| New feature?    |     no   |
| BC breaks?      | no       |
| Related Issue   | Fix #151 |
| Need Doc update |     no   |

## Describe your change

This PR removes an invalid search parameters applied to `SearchForHits`. The typing has been removed in algoliasearch-client-dart@1.27.2, preventing users from building their implementation when updating to this version.