### PR TITLE
fix(add*Searcher): debounce with constructor setting

### DIFF
--- a/helper/lib/src/searcher/multi_searcher.dart
+++ b/helper/lib/src/searcher/multi_searcher.dart
@@ -243,12 +243,7 @@ class _MultiSearcher with DisposableMixin implements MultiSearcher {
     _resultsSubscription = Rx.combineLatest(
       _delegates.map((e) => e.multiSearchState),
       (states) => states,
-    )
-        .debounceTime(
-          const Duration(milliseconds: 100),
-        )
-        .asyncMap(_service.search)
-        .listen((responses) {
+    ).debounceTime(debounce).asyncMap(_service.search).listen((responses) {
       for (var i = 0; i < responses.length; i++) {
         _delegates[i].updateResponse(responses[i]);
       }


### PR DESCRIPTION




| Q               | A        |
|-----------------|----------|
| Bug fix?        | yes  |
| New feature?    |no   |
| BC breaks?      | no       |
| Related Issue   | [CR-8778] |
| Need Doc update |no   |

## Describe your change

Instead of hardcoding a 100ms delay when you call addHits/FacetSearcher (through addDelegate), we debounce with the `debounce` class property set from the constructor.

Didn't add any tests as as far as I can tell this part of the code isn't tested

<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->

## What problem is this fixing?

You can delay more or less if you call this method a lot or late

<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->
