### PR TITLE
fix(multiSearcher): forward error

### DIFF
--- a/helper/lib/src/searcher/multi_searcher.dart
+++ b/helper/lib/src/searcher/multi_searcher.dart
@@ -252,6 +252,11 @@ class _MultiSearcher with DisposableMixin implements MultiSearcher {
       for (var i = 0; i < responses.length; i++) {
         _delegates[i].updateResponse(responses[i]);
       }
+    }, onError: (error, stack) {
+      // Propagate the error to all delegates
+      for (final delegate in _delegates) {
+        delegate.updateResponseError(error, stack);
+      }
     });
   }
 
@@ -295,6 +300,10 @@ abstract class MultiSearcherDelegate with DisposableMixin {
   ///   - `response`: The new [MultiSearchResponse] to set for the search unit.
   void updateResponse(MultiSearchResponse response) {
     _responseStream.add(response);
+  }
+
+  void updateResponseError(Object error, [StackTrace? stackTrace]) {
+    _responseStream.addError(error, stackTrace);
   }
 
   /// Provides public access to the stream of the encapsulated search units'


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        | yes  |
| New feature?    |no   |
| BC breaks?      | no       |
| Related Issue   | [CR-8778] |
| Need Doc update |no   |

## Describe your change

forward the error from all streams in multi searcher

<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->

## What problem is this fixing?

allows you to listen to errors like you can with a hits searcher

<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->


[CR-8778]: https://algolia.atlassian.net/browse/CR-8778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ