### PR TITLE
feat(search-reponse): expose renderingContent in model

### DIFF
--- a/helper/lib/src/model/multi_search_response.dart
+++ b/helper/lib/src/model/multi_search_response.dart
@@ -1,3 +1,4 @@
+import 'package:algoliasearch/algoliasearch.dart';
 import 'package:collection/collection.dart';
 import 'facet.dart';
 

--- a/helper/lib/src/model/search_response.dart
+++ b/helper/lib/src/model/search_response.dart
@@ -72,6 +72,12 @@ class SearchResponse extends MultiSearchResponse {
   /// This does not include network time.
   int get processingTimeMS => raw['processingTimeMS'] as int? ?? 0;
 
+  /// Defines how you want to render results in the search interface.
+  RenderingContent? get renderingContent => raw['renderingContent'] != null
+      ? RenderingContent.fromJson(
+          raw['renderingContent'] as Map<String, dynamic>)
+      : null;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        | no   |
| New feature?    | yes  |
| BC breaks?      | no       |
| Need Doc update | no   |

## Describe your change

[CR-9022](https://algolia.atlassian.net/browse/CR-9022)

## What problem is this fixing?

It does exist in the API Client, but the helper's model is not based on it, not sure why. Would it be worth just using the API Client model now ?
I added an import and a getter that casts it to the API model class.


[CR-9022]: https://algolia.atlassian.net/browse/CR-9022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ