### PR TITLE
fix(insights): properly divide viewed objects events

### DIFF
--- a/insights/lib/src/insights.dart
+++ b/insights/lib/src/insights.dart
@@ -202,7 +202,7 @@ class Insights implements EventTracker {
     final events = objectIDs
         .slices(_maxObjectIDsPerEvent)
         .map(
-          (filters) => Event.viewHits(
+          (objectIDs) => Event.viewHits(
             eventName,
             indexName,
             userToken,


### PR DESCRIPTION
| Q               | A        |
|-----------------|----------|
| Bug fix?        | yes  |
| New feature?    | no   |
| BC breaks?      | no       |
| Related Issue   | [CR-9049](https://algolia.atlassian.net/browse/CR-9049) |
| Need Doc update | no   |

## Describe your change

Seems like a problem with copy/pasting, variable shadowing and lack of linting tools.
Still named the variable the same as for other methods even if it shadows the upper scope `objectIDs` array.

## What problem is this fixing?

Events were split but sent the whole objectIDs array, causing an error


[CR-9049]: https://algolia.atlassian.net/browse/CR-9049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ